### PR TITLE
Enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
 
 ## Features
 
-  - **Comprehensive Command Support**: Now fully supports `gh repo create` and `gh repo delete` in addition to `archive`, `unarchive`, and others.
-  - **Enhanced `create` functionality**: You can specify the `description` and `visibility` (`public`, `private`, `internal`) for new repositories.
-  - **Simplified `delete` command**: Automates the repository deletion process, including the confirmation prompt.
-  - **Robust and Extensible**: The new `case` statement in the script makes it easy to add support for more `gh repo` subcommands in the future.
+  - **Comprehensive Command Support**: Fully supports `gh repo create` and `gh repo delete` in addition to `archive`, `unarchive`, and others.
+  - **Enhanced `create` functionality**: You can now specify the `description`, `visibility` (`public`, `private`, `internal`), and a **`team`** to be added to the new repository.
+  - **Initial Content**: Includes the option to initialize the new repository with a README file via the `add_readme` parameter or to use an existing repository as a `template`.
+  - **Robust and Extensible**: The `case` statement in the script makes it easy to add support for more `gh repo` subcommands in the future.
   - Uses the official [GitHub CLI](https://cli.github.com/) for robust repository management.
   - Simple integration in any GitHub Actions workflow.
 
------
 
 ## Requirements
 
@@ -23,7 +22,7 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
 
   - **Authentication Token**:
     The action uses the GitHub CLI, which expects an authentication token via the `GH_TOKEN` environment variable.
-    In most cases, you should use the built-in `${{ github.token }}` or `${{ secrets.GITHUB_TOKEN }}` in your workflow step. For creating or deleting repositories on behalf of a user or organization, a **Personal Access Token (PAT)** with appropriate scopes is recommended.
+    In most cases, you should use the built-in `${{ github.token }}` or `${{ secrets.GITHUB_TOKEN }}` in your workflow step. For operations like creating or deleting repositories on behalf of a user or organization, a **Personal Access Token (PAT)** with appropriate scopes is recommended.
 
     Example:
 
@@ -33,9 +32,8 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
     ```
 
   - **Permissions**:
-    The token must have sufficient permissions for the requested action on the target repository. This may require `contents: write` or broader `repo` scope permissions, especially for `create` and `delete` operations.
+    The token must have sufficient permissions for the requested action on the target repository. This may require `contents: write` or broader `repo` scope permissions. For adding a team, the token must also have permissions to manage team access within the organization.
 
------
 
 ## Inputs
 
@@ -46,24 +44,14 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
 | `repo_name` | Yes      | The repository name.                                                |
 | `description` | No | The repository description (for `create` action only). |
 | `visibility` | No | The repository visibility (`public`, `private`, or `internal`). Default is `public`. |
+| `team` | No | The name of a team to be added to the new repository. The team is granted `read` permission by default. |
+| `add_readme` | No | Set to `true` to initialize the new repository with a README.md file (for `create` action only). |
+| `template` | No | The repository to use as a template. Cannot be used with `add_readme` or `team` inputs. (for `create` action only). |
 
------
 
 ## Usage Examples
 
-**Example 1: Archive a repository**
-
-```yaml
-- uses: ws2git/gh-repo-action@v2
-  with:
-    action: "archive"
-    owner: "my-org"
-    repo_name: "my-repo"
-  env:
-    GH_TOKEN: ${{ github.token }}
-```
-
-**Example 2: Create a new private repository**
+**Example 1: Create a new private repository with a README**
 
 ```yaml
 - uses: ws2git/gh-repo-action@v2
@@ -73,11 +61,39 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
     repo_name: "my-private-project"
     description: "This is a private project created by an action."
     visibility: "private"
+    add_readme: "true"
   env:
     GH_TOKEN: ${{ secrets.MY_PAT }}
 ```
 
-**Example 3: Delete a repository**
+**Example 2: Create a new repository and add a team with `read` permission**
+
+```yaml
+- uses: ws2git/gh-repo-action@v2
+  with:
+    action: "create"
+    owner: "my-org"
+    repo_name: "my-team-project"
+    team: "dev-team"
+    visibility: "internal"
+  env:
+    GH_TOKEN: ${{ secrets.ORG_ADMIN_PAT }}
+```
+
+**Example 3: Create a repository from a template**
+
+```yaml
+- uses: ws2git/gh-repo-action@v2
+  with:
+    action: "create"
+    owner: "my-org"
+    repo_name: "my-project-from-template"
+    template: "my-org/my-template-repo"
+  env:
+    GH_TOKEN: ${{ secrets.MY_PAT }}
+```
+
+**Example 4: Delete a repository**
 
 ```yaml
 - uses: ws2git/gh-repo-action@v2
@@ -93,14 +109,15 @@ This GitHub Action allows you to execute `gh repo` commands (such as `archive`, 
 
 ## How it Works
 
-The action calls a shell script (`repo-action.sh`) that constructs the full repository identifier from the provided `owner` and `repo_name`, then passes your chosen action directly to the `gh repo` command with the appropriate parameters. The script uses a `case` statement to handle each command type and its specific arguments.
+The action calls a shell script (`repo-action.sh`) that constructs the full repository identifier from the provided `owner` and `repo_name`, then passes your chosen action directly to the `gh repo` command with the appropriate parameters. The script uses a `case` statement to handle each command type and its specific arguments. The `template`, `add_readme`, and `team` options are handled within the script to ensure they are used correctly based on GitHub CLI limitations.
 
 ## Limitations
 
   - The action does **not** validate whether the action is supported by the GitHub CLI or if the repository exists; errors from `gh` will cause the workflow step to fail.
-  - Both `owner` and `repo_name` must be provided for all actions that require a repository identifier (e.g., `archive`, `unarchive`, `delete`). For actions that do **not** require a repository (such as `gh repo create`), only `owner` and `repo_name` are required.
+  - Both `owner` and `repo_name` must be provided for all actions that require a repository identifier (e.g., `archive`, `unarchive`, `delete`). For the `create` action, only `owner` and `repo_name` are required.
   - The GitHub token used must have sufficient permissions for the requested operation.
   - The action does **not** check if the repository is already archived/unarchived/etc. before executing.
+  - The `template` input is mutually exclusive with the `team` and `add_readme` inputs due to GitHub CLI limitations.
   - Output and errors from the CLI are directly passed to the workflow logs.
 
 -----

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,19 @@ inputs:
     description: 'The repository description (optional, used with "create" action)'
     required: false
   visibility:
-    description: 'The repository visibility (public or private, default is "public" for "create" action)'
+    description: 'The repository visibility (public, private or internal, default is "public" for "create" action)'
     required: false
     default: 'public'
+  team:
+    description: 'The team to grant access to the new repository. (Used with "create" action)'
+    required: false
+  add_readme:
+    description: 'Set to "true" to initialize the new repository with a README. (Used with "create" action)'
+    required: false
+    default: 'false'
+  template:
+    description: 'The repository to use as a template. Cannot be used with add_readme or team inputs. (Used with "create" action)'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -33,4 +43,7 @@ runs:
           "${{ inputs.owner }}" \
           "${{ inputs.repo_name }}" \
           "${{ inputs.description }}" \
-          "${{ inputs.visibility }}"
+          "${{ inputs.visibility }}" \
+          "${{ inputs.team }}" \
+          "${{ inputs.add_readme }}" \
+          "${{ inputs.template }}"

--- a/repo-action.sh
+++ b/repo-action.sh
@@ -6,23 +6,49 @@ OWNER="$2"
 REPO_NAME="$3"
 DESCRIPTION="$4"
 VISIBILITY="$5"
+TEAM="$6"
+ADD_README="$7"
+TEMPLATE="$8"
 
+# Checking mandatory parameters
 if [[ -z "$ACTION" || -z "$OWNER" || -z "$REPO_NAME" ]]; then
-  echo "Usage: $0 <action> <owner> <repo_name> [<description>] [<visibility>]"
+  echo "Uso: $0 <action> <owner> <repo_name> [<description>] [<visibility>] [<team>] [<add_readme>] [<template>]"
+  echo "Exemplos:"
+  echo "  ./repo-manager.sh create my-org my-new-repo \"An incredible project!\" public my-team true"
+  echo "  ./repo-manager.sh create my-org template-project \"A new description\" -- -- \"\" my-org/my-template-repo"
   exit 1
 fi
 
 REPO="${OWNER}/${REPO_NAME}"
 
-# Inicializa o comando base e os argumentos
+# Initializes the base command and arguments
 COMMAND_ARGS=( "$ACTION" "$REPO" )
 
 case "$ACTION" in
   "create")
+
     if [[ -n "$DESCRIPTION" ]]; then
       COMMAND_ARGS+=( "--description" "$DESCRIPTION" )
     fi
-    # Adiciona a flag de visibilidade apenas se necessário
+    
+    # Checking restrictions on the --template parameter
+    if [[ -n "$TEMPLATE" ]]; then
+      if [[ "$ADD_README" == "true" || -n "$TEAM" ]]; then
+        echo "Erro: O parâmetro --template não pode ser usado com --add-readme ou --team."
+        exit 1
+      fi
+      COMMAND_ARGS+=( "--template" "$TEMPLATE" )
+    else
+      # Add the optional parameters only if you are not using --template
+      if [[ "$ADD_README" == "true" ]]; then
+        COMMAND_ARGS+=( "--add-readme" )
+      fi
+
+      if [[ -n "$TEAM" ]]; then
+        COMMAND_ARGS+=( "--team" "$TEAM" )
+      fi
+    fi
+
     if [[ "$VISIBILITY" == "private" ]]; then
       COMMAND_ARGS+=( "--private" )
     elif [[ "$VISIBILITY" == "internal" ]]; then
@@ -33,13 +59,13 @@ case "$ACTION" in
     COMMAND_ARGS+=( "--yes" )
     ;;
   *)
-    echo "Error: Unknown action '$ACTION'."
+    echo "Erro: Ação desconhecida '$ACTION'."
     exit 1
     ;;
 esac
 
-# Executa o comando gh com os argumentos do array
-echo "Running: gh repo ${COMMAND_ARGS[@]}"
+# Runs the gh command with the array arguments
+echo "Executando: gh repo ${COMMAND_ARGS[@]}"
 OUTPUT=$(gh repo "${COMMAND_ARGS[@]}" 2>&1)
 STATUS=$?
 


### PR DESCRIPTION
**New Feature: Expanded `create` Options with `team`, `add_readme`, and `template`**

This pull request builds on the previous enhancements by introducing new functionality to the `create` action. The underlying script has been further refined to support adding a team, initializing a repository with a README, and creating a new repository from a template.

---

### **Technical Details**

- **Refined `action.yml`**: The action now accepts three new optional inputs for the `create` action: `team`, `add_readme`, and `template`.
- **Improved `repo-action.sh`**:
    - The script now intelligently handles the new inputs, passing them directly to the `gh repo create` command.
    - It includes a validation check to enforce the GitHub CLI's limitation that the `template` parameter cannot be used with either `team` or `add_readme`.
    - The logic for building the command arguments has been carefully updated to accommodate these new optional flags.
- **Enhanced Flexibility**: This update provides more control over the initial state of newly created repositories, automating common setup tasks like assigning team access and adding initial files.

---

### **Motivation**

By adding these features, the action becomes a more powerful and comprehensive solution for repository automation. Users can now fully configure new repositories right from their workflow, reducing the need for manual post-creation steps. This enhancement streamlines administrative workflows and makes the action a more robust tool for managing repository lifecycles.

I'm confident these changes will be a valuable addition to the action. Please let me know if you have any questions or suggestions.